### PR TITLE
Fix broken dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ keywords = ["mongodb", "mongo", "oplog"]
 license = "MIT"
 
 [dependencies]
-bson = "^0.3.0"
-mongodb = "^0.1.8"
+bson = "^0.10.0"
+mongodb = "^0.3.0"
 chrono = "^0.2.0"


### PR DESCRIPTION
An upcoming change to the way type inference works in rust is going to break the old version of bson that this crate depends on. This updates to newer versions of bson and mongodb to avoid breakage.