### PR TITLE
Remove unnecessary lifetime for OplogBuilder::new

### DIFF
--- a/src/oplog.rs
+++ b/src/oplog.rs
@@ -93,7 +93,7 @@ impl<'a> OplogBuilder<'a> {
     /// }
     /// # }
     /// ```
-    pub fn new(client: &'a Client) -> OplogBuilder<'a> {
+    pub fn new(client: &Client) -> OplogBuilder {
         OplogBuilder {
             client: client,
             filter: None,


### PR DESCRIPTION
> If there is exactly one input lifetime position (elided or not), that
> lifetime is assigned to all elided output lifetimes.

(https://doc.rust-lang.org/beta/nomicon/lifetime-elision.html)

I tried to remove [this lifetime](https://github.com/mudge/oplog/blob/master/src/oplog.rs#L139) too as the same rule should apply, but the compiler wasn't happy. Strangely, it compiled when I changed `OplogBuilder` to `Self` in the return value, but I didn't want to make that change because then the signature would be inconsistent with the others.